### PR TITLE
Улучшение функционала gulp

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 let express = require('express');
 let app = express();
 
-app.set('views', './build/views');
+app.set('views', 'build/views');
 
 let exphbs = require('express-handlebars');
 
@@ -12,7 +12,7 @@ app.engine('.hbs', exphbs({
     partialsDir: 'build/hbs'
 }));
 
-app.use(express.static('build/public'));
+app.use('/static', express.static('build/public'));
 
 app.set('view engine', '.hbs');
 

--- a/app.js
+++ b/app.js
@@ -1,16 +1,19 @@
 let express = require('express');
 let app = express();
 
-app.set('views', './build');
+app.set('views', './build/views');
 
 let exphbs = require('express-handlebars');
 
 app.engine('.hbs', exphbs({
     defaultLayout: 'main',
     extname: '.hbs',
-    layoutsDir:'./build/layouts',
-    partialsDir: '/build/hbs'
+    layoutsDir: 'build/layouts',
+    partialsDir: 'build/hbs'
 }));
+
+app.use(express.static('build/public'));
+
 app.set('view engine', '.hbs');
 
 app.set('port', process.env.PORT || 8080);
@@ -28,7 +31,7 @@ let mongoOpt = {
 mongoose.Promise = global.Promise;
 mongoose.connect('mongodb://admin:1qazXSW@ds129090.mlab.com:29090/yaheckaton', mongoOpt);
 
-let routers = require('./src/controllers/routes');
+let routers = require('./build/controllers/routes');
 
 routers.initRouters(app);
 


### PR DESCRIPTION
-прописаны все watcher's
-избавление от коллизий в partials
--для того чтобы не было колизий в partials имена в build будут выглядеть так: путь-до-файла-из-blocks.hbs в шаблонах partials нужно будет указывать именно так
--важно учесть, что имя самого файла не фигурирует, т.к название директории должно быть именем папки
-добавлены layouts - это обособленная папка не относящаяся к partials
-добавлены views - тоже обособленная папка (gulp их определит если они лежать в blocks без папки)
-let => const (т.к мы ипользуем объекты, которые не будем изменять)
-public файлы (статика)