### PR TITLE
less цепляется к определенному блоку

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -132,8 +132,9 @@ gulp.task('style:build', () => {
                 return;
             }
             file.contents = Buffer.concat([
-                new Buffer('.' + className),
-                file.contents
+                new Buffer('.' + className+"{\n"),
+                file.contents,
+                new Buffer("}"),
             ]);
         }))
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -36,7 +36,6 @@ const path = {
     },
     src: { //Пути откуда брать исходники
         html: 'src/blocks/**/*.html', //мы хотим взять все файлы с расширением .html
-
         hb: 'src/blocks/**/*.hbs', //мы хотим взять все файлы с расширением .html
         views: 'src/blocks/*.hbs', //туту будут лежать вьюхи
         layouts: 'src/blocks/layouts/*.hbs', //layouts берем отсюда
@@ -66,6 +65,10 @@ const path = {
 };
 
 function getUniqueBlockName(directory) {
+    if (directory === '.') {
+
+        return '';
+    }
 
     return directory.split(Path.sep).join('-');
 }
@@ -77,9 +80,8 @@ gulp.task('html:build', () => {
 });
 
 gulp.task('hb:build', () => {
-    gulp.src([path.src.hb, '!' + path.src.layouts]) //Выберем файлы по нужному пути
+    gulp.src([path.src.hb, '!' + path.src.layouts, '!' + path.src.views]) //Выберем файлы по нужному пути
         .pipe(tap((file, t) => {
-
             let className = getUniqueBlockName(Path.dirname(file.relative));
             file.contents = Buffer.concat([
                 new Buffer(util.format('<div class="%s">\n', className)),
@@ -125,11 +127,16 @@ gulp.task('style:build', () => {
         .pipe(tap((file, t) => {
 
             let className = getUniqueBlockName(Path.dirname(file.relative));
+            if (!className) {
+
+                return;
+            }
             file.contents = Buffer.concat([
                 new Buffer('.' + className),
                 file.contents
             ]);
         }))
+
         .pipe(less()) //Скомпилируем
         .pipe(prefixer()) //Добавим вендорные префиксы
         .pipe(cssmin()) //Сожмем

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-rigger": "^0.5.8",
     "gulp-sourcemaps": "^2.4.1",
+    "gulp-tap": "^0.1.3",
     "gulp-uglify": "^2.1.0",
     "gulp-watch": "4.3.11",
     "hbs": "~4.0.1",

--- a/src/blocks/layouts/main.hbs
+++ b/src/blocks/layouts/main.hbs
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <title>Title</title>
+    <meta charset="UTF-8">
+    <link rel="stylesheet" type="text/css" href="/static/css/all.css">
+    <title>Title</title>
 </head>
 <body>
-    {{{body}}}
+{{{body}}}
 </body>
 </html>

--- a/src/blocks/main-page/description/description.less
+++ b/src/blocks/main-page/description/description.less
@@ -1,0 +1,6 @@
+{
+&:hover {
+    background: yellow;
+}
+
+}

--- a/src/blocks/main-page/description/description.less
+++ b/src/blocks/main-page/description/description.less
@@ -1,6 +1,6 @@
-{
+
 &:hover {
     background: yellow;
 }
 
-}
+

--- a/src/blocks/main-page/main-page.hbs
+++ b/src/blocks/main-page/main-page.hbs
@@ -1,2 +1,8 @@
-<h3>Im mainPage</h3>
-{{> main-page-description}}
+<section>
+    <h4>I'm main'page</h4>
+    <article>
+        {{> main-page-description}}
+
+    </article>
+    <a>123sdasd</a>
+</section>

--- a/src/blocks/main-page/main-page.less
+++ b/src/blocks/main-page/main-page.less
@@ -1,0 +1,10 @@
+{
+a {
+    color: green;
+}
+
+&:hover {
+    background: red;
+}
+
+}

--- a/src/blocks/main-page/main-page.less
+++ b/src/blocks/main-page/main-page.less
@@ -1,4 +1,8 @@
-{
+
+& {
+    background: green;
+}
+
 a {
     color: green;
 }
@@ -7,4 +11,5 @@ a {
     background: red;
 }
 
-}
+
+

--- a/src/blocks/styles.less
+++ b/src/blocks/styles.less
@@ -1,0 +1,19 @@
+
+html {
+
+}
+
+body {
+    //background-color: red ;
+    margin: 10px;
+}
+
+
+
+.bold {
+    font-weight: 800;
+}
+
+.center {
+    text-align: center;
+}


### PR DESCRIPTION
для каждой компоненты в blocks есть свой .hbs файлик и .less, так как уже все .hbs файлы будут скидываться в build без коллизий(им будут даваться индивидуальные имена в зависимости от вложенных папок которые и будут являться partials в handlebars), я предлагаю обернуть каждый .hbs компонент дивом с  селектором .<название partial> , а лежащий рядом .less файл будет не только скомпилирован в css, но еще перед всеми правилами установится нужный селектор нашего partial
таким образом можно будет less файлы радом с partials писать так:
```
        & {
             ....
        }
	a {
		...
	},
	&:hover {
		...
	}
```
т.е к верхним скобочкам добавится нужный нам селектор, и нам не нужно будет парится за зависимости между css файлами. так как именно эти стили пойдут только к этой компоненте

**layout и view файлы так не будут обрабатываються (тут быть внимательным)**
**также в layouts не должны лежать стили**

Если взглянуть на закомиченный пример, то в build/hbs/main-page.hbs будет:
```
<div class="main-page">
<section>
    <h4>I'm main'page</h4>
    <article>
        {{> main-page-description}}

    </article>
    <a>123sdasd</a>
</section>
<div>
```

А в build/public/css/all.css:
```
.main-page a{color:green}.main-page:hover{background:red}
.main-page-description:hover{background:#ff0}
...
```
