### PR TITLE
Поиск квестов

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,8 @@
   "globals": {
     "fetch": false,
     "Promise": false,
-    "document": false
+    "document": false,
+    "describe": false,
+    "it": false
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea/
 node_modules/
 build/
+.DS_Store
 
 # files:
 credentials.js

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -124,7 +124,7 @@ gulp.task('hb:build', () => {
             }
             file.contents = Buffer.concat([
                 new Buffer(headerBlock),
-                new Buffer(util.format('<div class="%s">\n', className)),
+                new Buffer(util.format('<div class="%s{{#if blockClass}} {{blockClass}}{{/if}}">\n', className)),
                 file.contents,
                 new Buffer('</div>')
             ]);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -281,6 +281,7 @@ gulp.task('js:lint', () => {
     gulp.src([path.src.js,
         'gulpfile.js',
         'app.js',
+        'tests/**/*.js',
         path.src.models,
         path.src.controllers,
         path.src.viewModels])
@@ -311,6 +312,7 @@ gulp.task('watch', () => {
     watch([path.watch.js,
         'gulpfile.js',
         'app.js',
+        'tests/**/*.js',
         path.src.models,
         path.src.controllers,
         path.src.viewModels], () => {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "cloudinary": "^1.8.0",
     "cookie-parser": "~1.4.3",
     "debug": "~2.6.0",
-    "eslint-config-xo": "^0.18.1",
+    "eslint-config-xo": "^0.17.0",
     "event-stream": "^3.3.4",
     "express": "^4.15.2",
     "express-handlebars": "^3.0.0",
@@ -64,12 +64,14 @@
     "stylelint-config-standard": "^16.0.0",
     "assert": "^1.4.1",
     "eslint": "^3.17.1",
-    "eslint-config-xo": "^0.17.0",
     "mocha": "^3.2.0",
     "stylelint": "^7.9.0"
   },
   "engines": {
     "node": "6.10.x",
     "npm": "3.10.x"
+  },
+  "devDependencies": {
+    "mocha": "^3.2.0"
   }
 }

--- a/src/blocks/general/numeric-input/numeric-input.hbs
+++ b/src/blocks/general/numeric-input/numeric-input.hbs
@@ -3,12 +3,13 @@
 {{#if label}}
     <label>{{label}}
 {{/if}}
-    <input type="text" class="form-control"
+    <input type="number" class="form-control"
         {{bind-attr id="id:id"}}
         {{bind-attr value="value:value"}}
         {{bind-attr value="placeholder:placeholder"}}
         {{bind-attr disabled="disabled:disabled"}}
         {{bind-attr onkeyup="onkeyup:onkeyup"}}
+        {{bind-attr onchange="onchange:onchange"}}
     />
 {{#if label}}
     </label>

--- a/src/blocks/main-page/main-page.hbs
+++ b/src/blocks/main-page/main-page.hbs
@@ -8,11 +8,13 @@
     <section class="quest-query">
         {{>general-button text='Создать квест' style='primary'}}
         {{>general-combo-box options=filter label="Сортировать"
-            onchange="filterQuests()"}}
-        {{>general-search-bar label="Поиск"
-            onkeyup="filterQuests()"}}
+            onchange="filtersChanged()"}}
+        {{>general-search-bar label="Входящая строка"
+            onkeyup="filtersChanged()"}}
+        {{>general-numeric-input label="Не менее"
+            onkeyup="filtersChanged()" onchange="filtersChanged()"}}
         {{>general-check-box label="В обратном порядке"
-            onchange="filterQuests()"}}
+            onchange="filtersChanged()"}}
     </section>
     <section class="quests">
 

--- a/src/blocks/main-page/main-page.hbs
+++ b/src/blocks/main-page/main-page.hbs
@@ -9,8 +9,10 @@
         {{>general-button text='Создать квест' style='primary'}}
         {{>general-combo-box options=filter label="Сортировать"
             onchange="filtersChanged()"}}
-        {{>general-search-bar label="Поиск"
+        {{>general-search-bar label="Входящая строка"
             onkeyup="filtersChanged()"}}
+        {{>general-numeric-input label="Не менее"
+            onkeyup="filtersChanged()" onchange="filtersChanged()"}}
         {{>general-check-box label="В обратном порядке"
             onchange="filtersChanged()"}}
     </section>

--- a/src/blocks/main-page/main-page.js
+++ b/src/blocks/main-page/main-page.js
@@ -4,23 +4,30 @@ function filtersChanged() {
     if (typeTimer) {
         clearTimeout(typeTimer);
     }
-
+    handleBlocks();
     typeTimer = setTimeout(filterQuests, 500);
 }
 
 function filterQuests() {
-    let url = '/questlist';
+    let url = '/quests';
     let questBlockElements = document.querySelectorAll('.quests-block');
     questBlockElements.forEach(el => {
         let queryElement = el.querySelector('.quest-query');
         let listElement = el.querySelector('.quests');
-        let value = queryElement.querySelector('select').value;
-        let reverse = queryElement.querySelector('input[type=checkbox]').checked;
-        let include = queryElement.querySelector('input[type=text]').value;
+        let value = queryElement.querySelector('.general-combo-box select').value;
+        let reverse = queryElement.querySelector('.general-check-box input').checked;
+        let include = queryElement.querySelector('.general-search-bar input').value;
+        let greaterThan = queryElement.querySelector('.general-numeric-input input').value;
         let params =
-            '?value=' + value +
-            '&reverse=' + reverse +
-            '&include=' + include + '&render=true';
+            '?render=true&Quest__opt__limit=50&' + value.replace('__', '__opt__sort__') + '=' + (reverse ? '-1' : '1');
+        if (include) {
+            params += '&' + value + '__include=' + include;
+        }
+
+        if (greaterThan) {
+            params += '&' + value + '__gte=' + greaterThan;
+        }
+
         fetch(url + params)
             .then(res => {
                 listElement.innerHTML = '';
@@ -34,4 +41,23 @@ function filterQuests() {
     });
 }
 
-filterQuests();
+function handleBlocks() {
+    let questBlockElements = document.querySelectorAll('.quests-block');
+    questBlockElements.forEach(el => {
+        let numericInput = el.querySelector('.general-numeric-input');
+        let searchBar = el.querySelector('.general-search-bar');
+        let comboBoxSelect = el.querySelector('.general-combo-box select');
+
+        if (['Quest__title', 'Author__name'].indexOf(comboBoxSelect.value) === -1) {
+            numericInput.style.display = 'block';
+            searchBar.querySelector('input').value = '';
+            searchBar.style.display = 'none';
+        } else {
+            numericInput.style.display = 'none';
+            numericInput.querySelector('input').value = '';
+            searchBar.style.display = 'block';
+        }
+    });
+}
+
+filtersChanged();

--- a/src/blocks/main-page/main-page.js
+++ b/src/blocks/main-page/main-page.js
@@ -1,17 +1,33 @@
 /* eslint no-unused-vars: 'off' */
+let typeTimer;
+function filtersChanged() {
+    if (typeTimer) {
+        clearTimeout(typeTimer);
+    }
+    handleBlocks();
+    typeTimer = setTimeout(filterQuests, 500);
+}
+
 function filterQuests() {
-    let url = '/questlist';
+    let url = '/quests';
     let questBlockElements = document.querySelectorAll('.quests-block');
     questBlockElements.forEach(el => {
         let queryElement = el.querySelector('.quest-query');
         let listElement = el.querySelector('.quests');
-        let value = queryElement.querySelector('select').value;
-        let reverse = queryElement.querySelector('input[type=checkbox]').checked;
-        let include = queryElement.querySelector('input[type=text]').value;
+        let value = queryElement.querySelector('.general-combo-box select').value;
+        let reverse = queryElement.querySelector('.general-check-box input').checked;
+        let include = queryElement.querySelector('.general-search-bar input').value;
+        let greaterThan = queryElement.querySelector('.general-numeric-input input').value;
         let params =
-            '?value=' + value +
-            '&reverse=' + reverse +
-            '&include=' + include + '&render=true';
+            '?render=true&Quest__opt__limit=50&' + value.replace('__', '__opt__sort__') + '=' + (reverse ? '-1' : '1');
+        if (include) {
+            params += '&' + value + '__include=' + include;
+        }
+
+        if (greaterThan) {
+            params += '&' + value + '__gte=' + greaterThan;
+        }
+
         fetch(url + params)
             .then(res => {
                 listElement.innerHTML = '';
@@ -25,4 +41,23 @@ function filterQuests() {
     });
 }
 
-filterQuests();
+function handleBlocks() {
+    let questBlockElements = document.querySelectorAll('.quests-block');
+    questBlockElements.forEach(el => {
+        let numericInput = el.querySelector('.general-numeric-input');
+        let searchBar = el.querySelector('.general-search-bar');
+        let comboBoxSelect = el.querySelector('.general-combo-box select');
+
+        if (['Quest__title', 'Author__name'].indexOf(comboBoxSelect.value) === -1) {
+            numericInput.style.display = 'block';
+            searchBar.querySelector('input').value = '';
+            searchBar.style.display = 'none';
+        } else {
+            numericInput.style.display = 'none';
+            numericInput.querySelector('input').value = '';
+            searchBar.style.display = 'block';
+        }
+    });
+}
+
+filtersChanged();

--- a/src/blocks/styles.less
+++ b/src/blocks/styles.less
@@ -5,3 +5,7 @@ html {
 body {
     margin: 10px;
 }
+
+.hidden {
+    display: none;
+}

--- a/src/controllers/query-parser.js
+++ b/src/controllers/query-parser.js
@@ -1,0 +1,93 @@
+/**
+ * парсит поля вида Model__key = value
+ * и Model__value__modification = value
+ * и пихает в data.find
+ *
+ * @param key - поле объекта для применения матчинга
+ * @param queryQueue - очередь модификаторов (include, gt, gte и пр.)
+ * @param data - результирующий объект для parseData
+ * @param value - значение опции
+ */
+function parseField(key, queryQueue, data, value) {
+    key = key.replace(/_/g, '.');
+    if (!queryQueue.length) {
+        data.find[key] = value;
+
+        return;
+    }
+
+    let subKey = queryQueue.shift();
+    if (subKey === 'include') {
+        data.find[key] = new RegExp('.*' + value + '.*');
+    } else {
+        data.find[key] = {};
+        data.find[key]['$' + subKey] = value;
+    }
+}
+
+/**
+ * парсит поля вида Model__opt__option__key = value
+ * и Model__opt__option = value
+ * и пихает в data.options
+ *
+ * @param opt - тип опции (limit, sort и тд)
+ * @param key - поле объекта для применения опции
+ * @param value - значение опции
+ * @param data - результирующий объект для parseData
+ */
+function parseOption(opt, key, value, data) {
+    if (!key) {
+        data.options[opt] = Number(value);
+
+        return;
+    }
+    if (!(opt in data.options)) {
+        data.options[opt] = {};
+    }
+    data.options[opt][key] = Number(-1 * value);
+}
+
+/**
+ *
+ * @param query - входящая response query
+ * @param prefix - модель к которй применяется опция
+ * @returns {{find: {}, options: {}}}
+ *
+ */
+function parseData(query, prefix) {
+    let data = {
+        find: {},
+        options: {}
+    };
+    Object.keys(query).filter(key => {
+        return key.startsWith(prefix);
+    }).forEach(key => {
+        let queryQueue = key.split('__');
+        queryQueue.shift();
+        let subKey = queryQueue.shift();
+        if (subKey === 'opt') {
+            parseOption(queryQueue.shift(), queryQueue.shift(), query[key], data);
+        } else {
+            parseField(subKey, queryQueue, data, query[key]);
+        }
+    });
+
+    return data;
+}
+/**
+ * парсит response query удобным для монги образом
+ *
+ * @param query - входящая response query
+ * @returns Object - объект распаршенный для mongoose
+ */
+module.exports = query => {
+    const data = {};
+    Object.keys(query).forEach(key => {
+        let prefix = key.split('__')[0];
+        if (!(prefix in data)) {
+            data[prefix] = parseData(query, prefix);
+        }
+    });
+
+    return data;
+};

--- a/src/controllers/quests.js
+++ b/src/controllers/quests.js
@@ -1,0 +1,82 @@
+require('../models/user');
+require('../models/photo');
+const Quest = require('../models/quest');
+const router = require('express').Router;
+const parseQuery = require('./query-parser');
+const app = router();
+
+/**
+ * callback функция сортировки моделей по populate field
+ *
+ * @param data - data.options.sort, где data - резултьтат работы query-parser
+ * @param populateName - имя populate field
+ * @param a - экземпляр 1
+ * @param b - экземпляр 2
+ * @returns {*}
+ */
+function sortPopulated(data, populateName, a, b) {
+    a = a[populateName];
+    b = b[populateName];
+    const keys = Object.keys(data);
+    for (let keyIndex = 0; keyIndex < keys.length; keyIndex++) {
+        let key = keys[keyIndex];
+        if (a[key] > b[key]) {
+            return -1 * data[key];
+        } else if (a[key] < b[key]) {
+            return data[key];
+        }
+    }
+
+    return 0;
+}
+
+app.get('/', (req, res) => {
+    let query = req.query;
+    let render = String(query.render);
+    delete query.render;
+    const parsedQuery = parseQuery(query);
+    let questData = parsedQuery.Quest || {find: {}, options: {}};
+    let authorData = parsedQuery.Author || {find: {}, options: {}};
+    questData.find.isPublished = 1;
+    Quest.find(
+        questData.find,
+        ['title', 'photos', 'description,', '-_id', 'id', 'likesCount', 'rating', 'author'],
+        questData.options
+    )
+        .populate({
+            path: 'author',
+            select: '-_id id name',
+            match: authorData.find
+        })
+        .populate('photos', '-_id url')
+        .exec()
+        .then(data => {
+            /*
+             * при матчинге populate field он не исключает из списка не подходящие, а заменяет на null
+             */
+            data = data.filter(instance => {
+                return instance.author !== null;
+            });
+
+            /*
+             * сортировка к populate fields не применяется
+             */
+            if (authorData.options.sort) {
+                data.sort(sortPopulated.bind(null, authorData.options.sort, 'author'));
+            }
+
+            if (render === 'true') {
+                res.render('quest-list', {
+                    quests: data,
+                    layout: false
+                });
+            } else {
+                res.send(data);
+            }
+        })
+        .catch(err => {
+            res.send('wrong parameters.' + err);
+        });
+});
+
+module.exports = app;

--- a/src/controllers/routes.js
+++ b/src/controllers/routes.js
@@ -1,80 +1,44 @@
 'use strict';
 
-const Quest = require('../models/quest');
 const QuestFilter = require('../view_models/quest-filter');
-require('../models/user');
-require('../models/photo');
 let questFilter = new QuestFilter();
 exports.initRouters = app => {
     app.get('/', (req, res) => {
-        /* eslint no-unused-vars: 0 */
         res.render('main-page', {
             filter: questFilter.toJson()
         });
     });
 
-    app.get('/questlist', (req, res) => {
-        /* eslint no-unused-vars: 0 */
-        let value;
-        if (req.query.value) {
-            value = req.query.value;
-        }
-        Quest.find()
-            .select('title author photos description -_id id likesCount rating')
-            .populate('author', '-_id id name')
-            .populate('photos', '-_id url')
-            .exec()
-            .then(data => {
-                data = questFilter.handle(value, data, req.query);
-                if (req.query.render === 'true') {
-                    res.render('quest-list', {
-                        quests: data,
-                        layout: false
-                    });
-                } else {
-                    res.send(data);
-                }
-            });
-    });
+    app.use('/quests', require('./quests'));
 
     app.get('/profile', () => {
-        /* eslint no-unused-vars: 0 */
     });
 
     app.get('/profile/:id', () => {
-            /* eslint no-unused-vars: 0 */
     });
 
     app.get('/quest/:id', () => {
-            /* eslint no-unused-vars: 0 */
     });
 
     app.get('/quest/:id/details', () => {
-            /* eslint no-unused-vars: 0 */
     });
 
     app.get('/myquests', () => {
-            /* eslint no-unused-vars: 0 */
     });
 
     app.get('/newquest', () => {
-            /* eslint no-unused-vars: 0 */
     });
 
     app.get('/editquest/:id', () => {
-            /* eslint no-unused-vars: 0 */
     });
 
     app.post('/signin', () => {
-            /* eslint no-unused-vars: 0 */
     });
 
     app.post('/signup', () => {
-            /* eslint no-unused-vars: 0 */
     });
 
     app.post('/rating', () => {
-            /* eslint no-unused-vars: 0 */
     });
 
     app.use((req, res) => {

--- a/src/view_models/filter.js
+++ b/src/view_models/filter.js
@@ -12,19 +12,6 @@ class Filter {
     toJson() {
         return this._opts;
     }
-
-    handle(value, data, opts) {
-        opts = opts || {};
-        value = value || this._opts[0].value;
-        if (!(value in this._handlers)) {
-            return data;
-        }
-        this._handlers[value].forEach(handler => {
-            data = handler(data, opts);
-        });
-
-        return data;
-    }
 }
 
 module.exports = Filter;

--- a/src/view_models/quest-filter.js
+++ b/src/view_models/quest-filter.js
@@ -1,78 +1,12 @@
 const Filter = require('./filter');
 
-function questSortFunction(sort, quests, opts) {
-    let sorted = quests;
-    sorted.sort(sort);
-    if (opts.reverse === 'true') {
-        sorted.reverse();
-    }
-
-    return sorted;
-}
-
-function questFilterFunction(filter, quests, opts) {
-    return quests.filter(filter.bind(null, opts));
-}
-
-function sortByName(a, b) {
-    return a.title.localeCompare(b.title);
-}
-
-function sortByLikes(a, b) {
-    return a.likesCount - b.likesCount;
-}
-
-function sortByRating(a, b) {
-    return a.rating - b.rating;
-}
-
-function sortByAuthor(a, b) {
-    return a.author.name.localeCompare(b.author.name);
-}
-
-function includeOptsPattern(data, opts) {
-    if (!opts.include) {
-        return true;
-    }
-
-    return String(data).toLowerCase().includes(opts.include.toLowerCase());
-}
-
-function filterByName(opts, quest) {
-    return includeOptsPattern(quest.title, opts);
-}
-
-function filterByLikes(opts, quest) {
-    return includeOptsPattern(quest.likesCount, opts);
-}
-
-function filterByRating(opts, quest) {
-    return includeOptsPattern(quest.rating, opts);
-}
-
-function filterByAuthor(opts, quest) {
-    return includeOptsPattern(quest.author.name, opts);
-}
-
 class QuestFilter extends Filter {
     constructor() {
         super();
-        super.addOption('name', 'По названию', [
-            questSortFunction.bind(null, sortByName),
-            questFilterFunction.bind(null, filterByName)
-        ]);
-        super.addOption('like', 'По лайкам', [
-            questSortFunction.bind(null, sortByLikes),
-            questFilterFunction.bind(null, filterByLikes)
-        ]);
-        super.addOption('rating', 'По рейтингу', [
-            questSortFunction.bind(null, sortByRating),
-            questFilterFunction.bind(null, filterByRating)
-        ]);
-        super.addOption('author', 'По автору', [
-            questSortFunction.bind(null, sortByAuthor),
-            questFilterFunction.bind(null, filterByAuthor)
-        ]);
+        super.addOption('Quest__rating', 'По рейтингу');
+        super.addOption('Quest__likesCount', 'По лайкам');
+        super.addOption('Quest__title', 'По названию');
+        super.addOption('Author__name', 'По автору');
     }
 }
 

--- a/tests/base-test.js
+++ b/tests/base-test.js
@@ -1,3 +1,0 @@
-var assert = require('assert');
-
-assert.equal(1, 1);

--- a/tests/quests-tests.js
+++ b/tests/quests-tests.js
@@ -19,7 +19,7 @@ describe('quests', () => {
                     'field2': /.*includeValue.*/,
                 },
                 options: {
-                    'sort': {'field2': -1},
+                    'sort': {'field2': 1},
                     'limit': 10
                 }
             },

--- a/tests/quests-tests.js
+++ b/tests/quests-tests.js
@@ -1,0 +1,35 @@
+const assert = require('assert');
+const parseQuery = require('../src/controllers/query-parser');
+describe('quests', () => {
+
+    it('test parseQuery function', () => {
+        assert.deepEqual(parseQuery({
+            'Model__field_name': 'value',
+            'Model__opt__sort__field2': -1,
+            'Model__opt__limit': 10,
+            'Model__field2__include': 'includeValue',
+            'AnotherModel__field_sub_name__gt': 1,
+
+            'AnotherModel__field_sub_name2__include': 'includeValue',
+        }),
+            {
+            'Model': {
+                find: {
+                    'field.name': 'value',
+                    'field2': /.*includeValue.*/,
+                },
+                options: {
+                    'sort': {'field2': -1},
+                    'limit': 10
+                }
+            },
+            'AnotherModel': {
+                find: {
+                    'field.sub.name': {'$gt': 1},
+                    'field.sub.name2': /.*includeValue.*/
+                },
+                options: {}
+            }
+        });
+    });
+});

--- a/tests/quests-tests.js
+++ b/tests/quests-tests.js
@@ -1,7 +1,7 @@
+/* eslint quote-props: ["error", "as-needed", { "keywords": true, "unnecessary": false }] */
 const assert = require('assert');
 const parseQuery = require('../src/controllers/query-parser');
 describe('quests', () => {
-
     it('test parseQuery function', () => {
         assert.deepEqual(parseQuery({
             'Model__field_name': 'value',
@@ -9,27 +9,26 @@ describe('quests', () => {
             'Model__opt__limit': 10,
             'Model__field2__include': 'includeValue',
             'AnotherModel__field_sub_name__gt': 1,
-
-            'AnotherModel__field_sub_name2__include': 'includeValue',
+            'AnotherModel__field_sub_name2__include': 'includeValue'
         }),
             {
-            'Model': {
-                find: {
-                    'field.name': 'value',
-                    'field2': /.*includeValue.*/,
+                'Model': {
+                    find: {
+                        'field.name': 'value',
+                        'field2': /.*includeValue.*/
+                    },
+                    options: {
+                        'sort': {'field2': 1},
+                        'limit': 10
+                    }
                 },
-                options: {
-                    'sort': {'field2': 1},
-                    'limit': 10
+                'AnotherModel': {
+                    find: {
+                        'field.sub.name': {'$gt': 1},
+                        'field.sub.name2': /.*includeValue.*/
+                    },
+                    options: {}
                 }
-            },
-            'AnotherModel': {
-                find: {
-                    'field.sub.name': {'$gt': 1},
-                    'field.sub.name2': /.*includeValue.*/
-                },
-                options: {}
-            }
-        });
+            });
     });
 });


### PR DESCRIPTION
-Сделано апи по поиску квестов по url
-По строковым данным в main-page ищем вхождение строки
-По числовым - значения не менее заданого
-Формат API:
Model__field=value - поиск по матчу поля field со значением value
Model__opt__option__field=value  - опция (sort, limit и тд) option с полем field и значением value
Model__opt__option=value - опция и значение
Model__field__modificator=value - поиск по модификатору (gt, gte, lt)
Model__field__include=value - поиск по маске .*$value.*
field_nested = field.nested
-Парсер для mongoose протестирован
-Плюс в том, что сейчас идет обращение сразу к БД и сортировка и фильтрация на той стороне
-Добавлен блок numeric-input