### PR TITLE
Drag'N'Drop fixes

### DIFF
--- a/src/blocks/general/drag-n-drop/drag-n-drop.js
+++ b/src/blocks/general/drag-n-drop/drag-n-drop.js
@@ -31,14 +31,14 @@ function initBlock(block) {
         block.classList.add('is-uploading');
         uploadFile(imgBlock.src)
             .then(link => {
-                uploadingBlock.style.display = 'none';
                 let imgBlockClone = imgBlock.cloneNode(true);
-                block.replaceWith(imgBlock);
                 /*
                  чтобы пользователь не видел мигающую картинку, нужно не просто поменять src,
                  а подменить на уже загруженный склоннированный img с подставленной новой ссылкой
                   */
                 imgBlockClone.addEventListener('load', () => {
+                    uploadingBlock.style.display = 'none';
+                    block.replaceWith(imgBlock);
                     imgBlock.parentNode.replaceChild(imgBlockClone, imgBlock);
                     block.dispatchEvent(loadedEvent);
                 });

--- a/src/blocks/general/drag-n-drop/drag-n-drop.less
+++ b/src/blocks/general/drag-n-drop/drag-n-drop.less
@@ -74,6 +74,7 @@ label:hover {
 }
 
 .svg {
+    border-radius: 0;
     display: block;
     margin: 5px auto;
     width: 25%;


### PR DESCRIPTION
-imgLoaded событие вызывалось в момент загрузки самой фотографии на клиенте, но надпись загрузки исчезала после успешной загрузки фотографии, поэтому некоторый промежуток времени интерфейс вел себя не так как нужно
-убрано закругление изображений